### PR TITLE
fix issues to support case sensitive file systems

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -15,7 +15,7 @@ open Fake.Git
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__
 
 let files includes = 
-  { BaseDirectories = [__SOURCE_DIRECTORY__]
+  { BaseDirectory = __SOURCE_DIRECTORY__
     Includes = includes
     Excludes = [] } |> Scan
 
@@ -155,7 +155,7 @@ Target "NuGet" (fun _ ->
     let description = description.Replace("\r", "").Replace("\n", "").Replace("  ", " ")
     let descriptionAspNet = descriptionAspNet.Replace("\r", "").Replace("\n", "").Replace("  ", " ")
     let descriptionGtk = descriptionAspNet.Replace("\r", "").Replace("\n", "").Replace("  ", " ")
-    let nugetPath = ".nuget/nuget.exe"
+    let nugetPath = ".nuget/NuGet.exe"
 
     if not compilingOnUnix then
       NuGet (fun p -> 
@@ -171,7 +171,8 @@ Target "NuGet" (fun _ ->
             ToolPath = nugetPath
             AccessKey = getBuildParamOrDefault "nugetkey" ""
             Publish = hasBuildParam "nugetkey"
-            Dependencies = [] })
+            Dependencies = [] 
+            WorkingDir = "./nuget" })
         "nuget/FSharp.Charting.nuspec"
 
     if not compilingOnUnix then
@@ -188,7 +189,8 @@ Target "NuGet" (fun _ ->
             ToolPath = nugetPath
             AccessKey = getBuildParamOrDefault "nugetkey" ""
             Publish = hasBuildParam "nugetkey"
-            Dependencies = [] })
+            Dependencies = [] 
+            WorkingDir = "./nuget" })
         "nuget/FSharp.Charting.AspNet.nuspec"
 
     NuGet (fun p -> 
@@ -204,7 +206,8 @@ Target "NuGet" (fun _ ->
             ToolPath = nugetPath
             AccessKey = getBuildParamOrDefault "nugetkey" ""
             Publish = hasBuildParam "nugetkey"
-            Dependencies = [] })
+            Dependencies = [] 
+            WorkingDir = "./nuget" })
         "nuget/FSharp.Charting.Gtk.nuspec"
 
 )

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ ! -f tools/FAKE/tools/Fake.exe ]; then
-  mono .NuGet/NuGet.exe install FAKE -OutputDirectory tools -ExcludeVersion -Prerelease
+if [ ! -f tools/FAKE/tools/FAKE.exe ]; then
+  mono .nuget/NuGet.exe install FAKE -OutputDirectory tools -ExcludeVersion -Prerelease
 fi
 mono tools/FAKE/tools/FAKE.exe build.fsx $@

--- a/src/FSharp.Charting.Gtk.fsproj
+++ b/src/FSharp.Charting.Gtk.fsproj
@@ -75,10 +75,12 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName)$(TargetExt)" DestinationFolder="$(SolutionDir)bin\v40" />
-    <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)bin\v40" />
+    <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)bin\v40" Condition="Exists('$(ProjectDir)$(OutDir)$(TargetName).pdb')" />
+    <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).mdb" DestinationFolder="$(SolutionDir)bin\v40" Condition="Exists('$(ProjectDir)$(OutDir)$(TargetName).mdb')" />
     <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).xml" DestinationFolder="$(SolutionDir)bin\v40" />
     <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName)$(TargetExt)" DestinationFolder="$(SolutionDir)bin" />
-    <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)bin" />
+    <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)bin" Condition="Exists('$(ProjectDir)$(OutDir)$(TargetName).pdb')"/>
+    <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).mdb" DestinationFolder="$(SolutionDir)bin" Condition="Exists('$(ProjectDir)$(OutDir)$(TargetName).mdb')"/>
     <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).xml" DestinationFolder="$(SolutionDir)bin" />
     <Copy SourceFiles="$(ProjectDir)$(OutDir)$(TargetName).fsx" DestinationFolder="$(SolutionDir)bin" />
     <Copy SourceFiles="$(ProjectDir)$(OutDir)OxyPlot.dll" DestinationFolder="$(SolutionDir)bin" />


### PR DESCRIPTION
I had to put a condition for the AfterBuild task which copies the .pdb so it only do so if the file exists. I added a similar Copy task for .mdb which are the debugging databases emitted by mono's compiler.

In the Fake build script, I had to override the working dir to match with the actual directory containing the .nuspec files.

I'll consider fixing Fake's NuGetHelper but I'm unsure yet what how this folder is supposed to be named.

Now I can use the "build" target with Fake to build the assembly, though there is still an issue while generating the .nuspec file:

```
Creating .nuspec file at /home/gauthier/mystuff/FSharp.Charting/nuget/FSharp.Charting.Gtk.0.90.6.nuspec
Created nuspec file /home/gauthier/mystuff/FSharp.Charting/nuget/FSharp.Charting.Gtk.0.90.6.nuspec
mono  .nuget/NuGet.exe pack "/home/gauthier/mystuff/FSharp.Charting/nuget/FSharp.Charting.Gtk.0.90.6.nuspec" -Version 0.90.6 -OutputDirectory "/home/gauthier/mystuff/FSharp.Charting/bin"  
Cannot open assembly '.nuget/NuGet.exe': No such file or directory.
Running build failed.
Error:
System.Exception: Error during NuGet package creation. .nuget/NuGet.exe pack "/home/gauthier/mystuff/FSharp.Charting/nuget/FSharp.Charting.Gtk.0.90.6.nuspec" -Version 0.90.6 -OutputDirectory "/home/gauthier/mystuff/FSharp.Charting/bin"  
  at Fake.NuGetHelper.NuGet (Microsoft.FSharp.Core.FSharpFunc`2 setParams, System.String nuspecFile) [0x00000] in <filename unknown>:0 
  at FSI_0001+clo@152-15.Invoke (Microsoft.FSharp.Core.Unit _arg8) [0x00000] in <filename unknown>:0 
  at Fake.TargetHelper+targetFromTemplate@138[Microsoft.FSharp.Core.Unit].Invoke (Microsoft.FSharp.Core.Unit unitVar0) [0x00000] in <filename unknown>:0 
  at Fake.TargetHelper.runTarget@290 (System.String targetName) [0x00000] in <filename unknown>:0 
```

but I think this needs to be troubleshooted in Fake itself.
