### PR TITLE
Ignore the output of ch.ShowChart() in the fsx helper files

### DIFF
--- a/src/FSharp.Charting.Gtk.fsx
+++ b/src/FSharp.Charting.Gtk.fsx
@@ -93,5 +93,5 @@ fsi.EventLoop <-
 
 open FSharp.Charting
 module FsiAutoShow = 
-    fsi.AddPrinter(fun (ch:FSharp.Charting.ChartTypes.GenericChart) -> ch.ShowChart(); "(Chart)")
+    fsi.AddPrinter(fun (ch:FSharp.Charting.ChartTypes.GenericChart) -> ch.ShowChart() |> ignore; "(Chart)")
 

--- a/src/FSharp.Charting.fsx
+++ b/src/FSharp.Charting.fsx
@@ -24,5 +24,5 @@
 
 open FSharp.Charting
 module FsiAutoShow = 
-    fsi.AddPrinter(fun (ch:FSharp.Charting.ChartTypes.GenericChart) -> ch.ShowChart(); "(Chart)")
+    fsi.AddPrinter(fun (ch:FSharp.Charting.ChartTypes.GenericChart) -> ch.ShowChart() |> ignore; "(Chart)")
 


### PR DESCRIPTION
This is to avoid the following error:

warning FS0020: This expression should have type 'unit', but has type 'Windows.Forms.Form'. Use 'ignore' to discard the result of the expression, or 'let' to bind the result to a name.
