### PR TITLE
Add Show and Save methods to Chart helper class.

### DIFF
--- a/src/FSharp.Charting.fs
+++ b/src/FSharp.Charting.fs
@@ -3112,6 +3112,25 @@ namespace FSharp.Charting
         static member Combine charts = 
           CombinedChart (List.ofSeq charts) :> GenericChart
 
+        /// Display a chart
+        static member public Show (chart:GenericChart) =
+                use cc = new ChartControl(chart)
+                cc.Dock <- DockStyle.Fill
+                use f = new Form()
+                f.Size <- System.Drawing.Size(800, 600)
+                f.Controls.Add cc
+                f.ShowDialog() |> ignore
+
+        /// Save a chart to a file in png format
+        static member Save filename (chart:GenericChart) =
+            use cc = new ChartControl(chart)
+            cc.Dock <- DockStyle.Fill
+            use f = new Form()
+            f.Size <- System.Drawing.Size(800, 600)
+            f.Controls.Add cc
+            f.Load |> Event.add (fun _ -> chart.SaveChartAs(filename, ChartImageFormat.Png); f.Close()) 
+            Application.Run f
+
 
     /// Contains static methods to construct charts whose data source is an event or observable which 
     /// updates the entire data set.

--- a/tests/Chart.Tests.fs
+++ b/tests/Chart.Tests.fs
@@ -111,3 +111,14 @@ let ``Test that chart specifications compile``() =
 
     checkChartWithBothMarginVisibilities (Chart.Line [ 0 .. 10 ])
     checkChartWithBothMarginVisibilities (Chart.Point [ 0 .. 10 ])
+
+    let checkSave chart filename =
+        System.IO.File.Exists(filename)
+        |> should equal false
+        chart
+        |> Chart.Save filename
+        System.IO.File.Exists(filename)
+        |> should equal true
+        System.IO.File.Delete(filename)
+
+    checkSave (Chart.Line [ 0 .. 10 ]) "chart.png"


### PR DESCRIPTION
Here is an attempt to close issues #26 and #38. There's some cognitive dissonance having SaveChartAs as a member of GenericChart and then Save as a member of Chart, but it's difficult to define the Save method in GenericChart itself due to the dependence on ChartControl.  It would be worthwhile to document this extension method and explain why it might be preferred over GenericChart.SaveChartAs

The solution uses the Chart extension code suggested by @stmax82 in issue #26. 

Added test revises the local filesystem and deletes the created file (which seems dangerous if the file already exists).  Test should fail if the file exists but I'm not 100% confident it will bail out before attempting the delete.

Tested on Windows- no idea how it will behave on other systems.