### PR TITLE
Update to OxyPlot.GtkSharp 2014.1.546

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,7 +2,6 @@ source https://nuget.org/api/v2
 
 nuget FSharp.Formatting
 nuget NUnit
-nuget GtkSharp
 nuget NUnit.Runners 
 nuget OxyPlot.GtkSharp 2014.1.546
 nuget OxyPlot.Core 2014.1.546

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -4,7 +4,7 @@ nuget FSharp.Formatting
 nuget NUnit
 nuget GtkSharp
 nuget NUnit.Runners 
-nuget OxyPlot.GtkSharp 2013.2.119.1
-nuget OxyPlot.Core 2013.2.119.1
+nuget OxyPlot.GtkSharp 2014.1.546
+nuget OxyPlot.Core 2014.1.546
 nuget Nuget.CommandLine
 nuget FAKE

--- a/paket.lock
+++ b/paket.lock
@@ -1,17 +1,17 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    FAKE (3.28.7)
-    FSharp.Compiler.Service (0.0.89)
-    FSharp.Formatting (2.8.0)
-      FSharp.Compiler.Service (>= 0.0.86)
-      FSharpVSPowerTools.Core (>= 1.7.0)
+    FAKE (3.35.4)
+    FSharp.Compiler.Service (0.0.90)
+    FSharp.Formatting (2.9.9)
+      FSharp.Compiler.Service (>= 0.0.87)
+      FSharpVSPowerTools.Core (1.8.0)
     FSharpVSPowerTools.Core (1.8.0)
       FSharp.Compiler.Service (>= 0.0.87)
     GtkSharp (3.1.2)
     NuGet.CommandLine (2.8.5)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
-    OxyPlot.Core (2013.2.119.1)
-    OxyPlot.GtkSharp (2013.2.119.1)
-      OxyPlot.Core
+    OxyPlot.Core (2014.1.546)
+    OxyPlot.GtkSharp (2014.1.546)
+      OxyPlot.Core (2014.1.546)

--- a/src/FSharp.Charting.Gtk.fs
+++ b/src/FSharp.Charting.Gtk.fs
@@ -652,11 +652,11 @@ namespace FSharp.Charting
                 | :? INotifyCollectionChanged as i -> 
                       let rec handler = NotifyCollectionChangedEventHandler(fun _ _ -> 
                         series.ItemsSource <- data
-                        match model.PlotControl with 
+                        match model.PlotView with 
                         | null -> ()
                         | _ ->  
                            // An exception will indicate form is no longer working, e.g. shutdown or disposed, so disconnect
-                           try model.RefreshPlot(true) 
+                           try model.InvalidatePlot(true) 
                            with _ -> i.CollectionChanged.RemoveHandler handler)
                       i.CollectionChanged.AddHandler handler
                 | _ -> ()
@@ -2387,7 +2387,7 @@ namespace FSharp.Charting
 #endif
             /// Display the chart in a new Gtk.Window()
             member ch.ShowChart () =
-                let plot = new OxyPlot.GtkSharp.Plot(Model = ch.Model )
+                let plot = new OxyPlot.GtkSharp.PlotView(Model = ch.Model )
                 let win = new Gtk.Window(ProvideTitle ch)
                 plot.SetSizeRequest(700, 500)
                 win.SetSizeRequest(700, 500)

--- a/src/FSharp.Charting.Gtk.fsproj
+++ b/src/FSharp.Charting.Gtk.fsproj
@@ -56,6 +56,26 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\atk-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\gdk-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\glib-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\Program Files (x86)\GtkSharp\2.12\lib\gtk-sharp-2.0\gtk-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cairo, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\Program Files (x86)\GtkSharp\2.12\lib\Mono.Cairo\Mono.Cairo.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
@@ -104,34 +124,9 @@
     <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
       <ItemGroup>
         <Reference Include="OxyPlot.GtkSharp">
-          <HintPath>..\packages\OxyPlot.GtkSharp\lib\NET40\OxyPlot.GtkSharp.dll</HintPath>
+          <HintPath>..\packages\OxyPlot.GtkSharp\lib\net40\OxyPlot.GtkSharp.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
-        </Reference>
-        <Reference Include="OxyPlot">
-          <HintPath>..\packages\OxyPlot.GtkSharp\lib\NET40\OxyPlot.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="gtk-sharp">
-          <Paket>True</Paket>
-          <Private>True</Private>
-          <HintPath>..\packages\GtkSharp\lib\net45\gtk-sharp.dll</HintPath>
-        </Reference>
-        <Reference Include="gdk-sharp">
-          <Paket>True</Paket>
-          <Private>True</Private>
-          <HintPath>..\packages\GtkSharp\lib\net45\gdk-sharp.dll</HintPath>
-        </Reference>
-        <Reference Include="atk-sharp">
-          <Paket>True</Paket>
-          <Private>True</Private>
-          <HintPath>..\packages\GtkSharp\lib\net45\atk-sharp.dll</HintPath>
-        </Reference>
-        <Reference Include="glib-sharp">
-          <Paket>True</Paket>
-          <Private>True</Private>
-          <HintPath>..\packages\GtkSharp\lib\net45\glib-sharp.dll</HintPath>
         </Reference>
       </ItemGroup>
     </When>


### PR DESCRIPTION
Also remove invalid gtk-sharp-3 reference

It would be nice to have an new up2date FSharp.Charting.Gtk release again. At the momen 0.90.10 is broken on Gtk systems