### PR TITLE
Add relevant include directories for Ubuntu

### DIFF
--- a/src/FSharp.Charting.Gtk.fsx
+++ b/src/FSharp.Charting.Gtk.fsx
@@ -27,6 +27,12 @@
 #I "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/gtk-sharp-2.0"
 #I "/usr/lib/mono/gtk-sharp-2.0"
 
+// In Ubuntu, GTK-sharp libraries are split into various directories
+#I "/usr/lib/cli/glib-sharp-2.0/"
+#I "/usr/lib/cli/atk-sharp-2.0/"
+#I "/usr/lib/cli/gtk-sharp-2.0/"
+#I "/usr/lib/cli/gdk-sharp-2.0/"
+
 #r "gtk-sharp.dll"
 #r "gdk-sharp.dll"
 #r "atk-sharp.dll"


### PR DESCRIPTION
In Ubuntu and the likes gtk-sharp, atk-sharp, gdk-sharp and glib-sharp are split into different directories. Thus it would help to have these automatically included in the script. It is also all important that the libglibsharpglue-2.so and appropriate .config files can be found on the path. The active includes should not hurt, even, if the directories are not present, but it is OK also to comment them out.
