### PR TITLE
Access to the underlying .NET chart object

### DIFF
--- a/docs/content/FurtherSamples.fsx
+++ b/docs/content/FurtherSamples.fsx
@@ -189,3 +189,16 @@ Chart.Stock(timeHighLowOpenClose)
 Chart.ThreeLineBreak(data,Name="SomeData").WithDataPointLabels(PointToolTip="Hello, I am #SERIESNAME") 
 
 Chart.Histogram([for x in 1 .. 100 -> rand()*10.],LowerBound=0.,UpperBound=10.,Intervals=10.)
+
+// Example of .ApplyToChart() used to alter the settings on the window chart and to access the chart child objects.
+// This can normally be done manually, in the chart property grid (right click the chart, then "Show Property Grid"). 
+// This is useful when you want to try out carious settings first. But once you know what you want, .ApplyToChart() 
+// allows programmatic access to the window properties. The two examples below are: IsUserSelectionEnabled essentially 
+// allows zooming in and out along the given axes, and the longer fiddly example below does the same work as .WithDataPointLabels() 
+// but across all series objects.
+[ Chart.Column(data); 
+  Chart.Column(data2) |> Chart.WithSeries.AxisType( YAxisType = Windows.Forms.DataVisualization.Charting.AxisType.Secondary ) ]
+|> Chart.Combine
+|> fun c -> c.WithLegend()
+             .ApplyToChart( fun c -> c.ChartAreas.[0].CursorX.IsUserSelectionEnabled <- true )
+             .ApplyToChart( fun c -> let _ = [0 .. c.Series.Count-1] |> List.map ( fun s -> c.Series.[ s ].ToolTip <- "#SERIESNAME (#VALX, #VAL{0:00000})" ) in () )

--- a/docs/content/fsharpcharting.md
+++ b/docs/content/fsharpcharting.md
@@ -41,7 +41,7 @@ The following methods are used to style chart objects:
  * `WithTitle`
  * `WithXAxis`
  * `WithYAxis`
-
+ * `ApplyToChart`
 
 Please [contribute](contributing.html) more documentation on the following topics:
 

--- a/src/FSharp.Charting.fs
+++ b/src/FSharp.Charting.fs
@@ -1145,6 +1145,7 @@ namespace FSharp.Charting
 
             let mutable data = ChartData.Values (NotifySeq.ignoreReset (NotifySeq.notifyOrOnce []), ChartValueType.Auto, "Item1", "Item2", "") 
             let mutable margin = DefaultMarginForEachChart
+            let mutable customizationFunctions : (Chart -> unit) list = []
 
             [<Obsolete("This type does not support GetHashCode()")>]
             override x.GetHashCode() = 0
@@ -1165,9 +1166,10 @@ namespace FSharp.Charting
             member internal x.Chart with get() = chart.Value and set v = chart <- evalLazy v
             member internal x.Margin with get() = margin and set v = margin <- v
             member internal x.Name with get() = name and set v = name <- v
+            member internal x.CustomizationFunctions with get() = customizationFunctions
 
             member x.ApplyToChart ( fn : Chart -> unit ) =
-                fn x.Chart
+                customizationFunctions <- ( fn :: customizationFunctions )
                 x
 
             /// Ensure the chart has a Title
@@ -3954,6 +3956,7 @@ namespace FSharp.Charting
                 frm.Text <- ProvideTitle ch
                 frm.Controls.Add(ctl)
                 frm.Show()
+                ch.CustomizationFunctions |> List.map (fun fn -> fn ch.Chart) |> ignore
                 ctl.Focus() |> ignore
                 frm
 

--- a/src/FSharp.Charting.fs
+++ b/src/FSharp.Charting.fs
@@ -3956,7 +3956,7 @@ namespace FSharp.Charting
                 frm.Text <- ProvideTitle ch
                 frm.Controls.Add(ctl)
                 frm.Show()
-                ch.CustomizationFunctions |> List.map (fun fn -> fn ch.Chart) |> ignore
+                ch.CustomizationFunctions |> List.rev |> List.map (fun fn -> fn ch.Chart) |> ignore
                 ctl.Focus() |> ignore
                 frm
 

--- a/src/FSharp.Charting.fs
+++ b/src/FSharp.Charting.fs
@@ -1166,6 +1166,9 @@ namespace FSharp.Charting
             member internal x.Margin with get() = margin and set v = margin <- v
             member internal x.Name with get() = name and set v = name <- v
 
+            member x.ApplyToChart ( fn : Chart -> unit ) =
+                fn x.Chart
+
             /// Ensure the chart has a Title
             member internal x.ForceTitle() = 
                 match title with 

--- a/src/FSharp.Charting.fs
+++ b/src/FSharp.Charting.fs
@@ -1168,6 +1168,7 @@ namespace FSharp.Charting
 
             member x.ApplyToChart ( fn : Chart -> unit ) =
                 fn x.Chart
+                x
 
             /// Ensure the chart has a Title
             member internal x.ForceTitle() = 


### PR DESCRIPTION
Exposed access to the underlying System.Windows.Forms.DataVisualization.Charting.Chart object via a "visitor"-esque member method ApplyToChart(...), in order to enable programmatic control over the chart form window. This control is already possible to perform manually via the Properties tab of the chart form. 

This enables us to use charting with the following example pattern:

```
let inputData = [1;2;3]
inputData
|> Chart.Line
|> fun c      -> c.WithLegend()  // add legend using the existing method
|> fun c      -> ( c, c.ShowChart() )    // create the chart form
|> fun (c, _) -> (c, c.ApplyToChart( fun c -> c.ChartAreas.[0].CursorX.IsUserSelectionEnabled <- true ) )   // can now modify chart form using all of the available .NET Chart API by chaining lines like this one
|> ignore   // avoid displaying the chart twice
```