### PR TITLE
Fixed the location of the FSharp.Charting.fsx file in the NuGet package

### DIFF
--- a/nuget/FSharp.Charting.template
+++ b/nuget/FSharp.Charting.template
@@ -19,4 +19,4 @@ files
     ../bin/FSharp.Charting.dll ==> lib/net45
     ../bin/FSharp.Charting.xml ==> lib/net45
     ../bin/FSharp.Charting.pdb ==> lib/net45
-    ../bin/FSharp.Charting.fsx ==> lib/net45
+    ../bin/FSharp.Charting.fsx ==> .

--- a/src/FSharp.Charting.fsx
+++ b/src/FSharp.Charting.fsx
@@ -16,7 +16,7 @@
 #r "System.Windows.Forms.DataVisualization.dll"
 #nowarn "211"
 #I __SOURCE_DIRECTORY__
-#I "lib/net40"
+#I "lib/net45"
 #r "FSharp.Charting.dll"
 
 open FSharp.Charting


### PR DESCRIPTION
Fixed the location of the FSharp.Charting.fsx file in the NuGet package and its reference to the FSharp.Charting.dll which is now under 'net45'. I found this problem following the code in the book 'Machine Learning Projects for .NET Developers', page 96. The location of the FSharp.Charting.fsx file in the NuGet package was inconsistent with the path to the dll. There were multiple ways to fix this. I choose the way that is consistent with the book example.